### PR TITLE
Feature/support post with hesa url

### DIFF
--- a/IngestRawXmlHttpTrigger/test-scripts/post-url.sh
+++ b/IngestRawXmlHttpTrigger/test-scripts/post-url.sh
@@ -1,0 +1,7 @@
+# Run this script to POST a URL to the IngestRawXmlHtmlTrigger
+# Azure Function. Modify as required to meet your specific 
+# requirements.
+curl --header "Content-Type: application/json" \
+    --request POST \
+    --data '{"resource_url":"http://somehost.com/somepath"}' \
+    http://localhost:7071/api/IngestRawXmlHttpTrigger

--- a/IngestRawXmlHttpTrigger/utils.py
+++ b/IngestRawXmlHttpTrigger/utils.py
@@ -1,12 +1,12 @@
-import logging
-
 
 def get_url_from_req(req):
     """Returns the value of resource_url from the HTTP request"""
+
+    # TODO Update when we have finalised details on POST format
     try:
-        req_body = req.get_json()
-        url = req_body['resource_url']
-    except (ValueError, KeyError):
+        req_json = req.get_json()
+        url = req_json['resource_url']
+    except (AttributeError, TypeError, ValueError, KeyError):
         raise OfsMissingUrlError
 
     return url

--- a/IngestRawXmlHttpTrigger/utils.py
+++ b/IngestRawXmlHttpTrigger/utils.py
@@ -5,7 +5,7 @@ def get_url_from_req(req):
     """Returns the value of resource_url from the HTTP request"""
     try:
         req_body = req.get_json()
-        url = req_body["resource_url"]
+        url = req_body['resource_url']
     except (ValueError, KeyError):
         raise MissingUrlError
 

--- a/IngestRawXmlHttpTrigger/utils.py
+++ b/IngestRawXmlHttpTrigger/utils.py
@@ -1,0 +1,17 @@
+import logging
+
+
+def get_url_from_req(req):
+    """Returns the value of resource_url from the HTTP request"""
+    try:
+        req_body = req.get_json()
+        url = req_body["resource_url"]
+    except (ValueError, KeyError):
+        raise MissingUrlError
+
+    return url
+
+
+class MissingUrlError(Exception):
+   """Raised when the POST body does not contain a JSON encoded URL value"""
+   pass

--- a/IngestRawXmlHttpTrigger/utils.py
+++ b/IngestRawXmlHttpTrigger/utils.py
@@ -7,11 +7,11 @@ def get_url_from_req(req):
         req_body = req.get_json()
         url = req_body['resource_url']
     except (ValueError, KeyError):
-        raise MissingUrlError
+        raise OfsMissingUrlError
 
     return url
 
 
-class MissingUrlError(Exception):
-   """Raised when the POST body does not contain a JSON encoded URL value"""
+class OfsMissingUrlError(Exception):
+   """Raised when the POST body does not contain the expected resource URL value"""
    pass

--- a/unittests.py
+++ b/unittests.py
@@ -6,25 +6,42 @@ from IngestRawXmlHttpTrigger.utils import get_url_from_req, OfsMissingUrlError
 
 class TestGetUrlFromReq(unittest.TestCase):
     def setUp(self):
-        self.test_url = 'http://somehost.com/somepath'
-        self.valid_data = {
+        self.test_url = 'http://thehostwegetxmlfrom.com/somepath'
+        self.valid_json = {
             'resource_url': self.test_url}
-        self.invalid_data = {
-            'invalid_name': self.test_url}
+        self.invalid_json_name = {
+            'invalid_json_name': self.test_url}
+        self.empty_json_object = "{}"
+        self.empty_body = ""
 
-    def test_with_valid_data(self):
-        """Test with valid body data"""
-        valid_body = json.dumps(self.valid_data)
+    def test_with_valid_json(self):
+        """Test with valid json"""
+        valid_body = json.dumps(self.valid_json)
         http_req = func.HttpRequest(
             method='post', url='http://somehost.com/somepath', body=valid_body.encode('ASCII'))
         url = get_url_from_req(http_req)
         self.assertEqual(url, self.test_url)
 
-    def test_with_invalid_data(self):
-        """Test with invalid POST body data"""
-        invalid_body = json.dumps(self.invalid_data)
+    def test_with_invalid_json_name(self):
+        """Test with invalid json name"""
+        invalid_body = json.dumps(self.invalid_json_name)
         http_req = func.HttpRequest(
             method='post', url='http://somehost.com/somepath', body=invalid_body.encode('ASCII'))
+        with self.assertRaises(OfsMissingUrlError):
+            get_url_from_req(http_req)
+
+    def test_with_empty_json_object(self):
+        """Test with empty json object"""
+        invalid_body = json.dumps(self.empty_json_object)
+        http_req = func.HttpRequest(
+            method='post', url='http://somehost.com/somepath', body=invalid_body.encode('ASCII'))
+        with self.assertRaises(OfsMissingUrlError):
+            get_url_from_req(http_req)
+
+    def test_with_empty_body(self):
+        """Test with empty POST body"""
+        http_req = func.HttpRequest(
+            method='post', url='http://somehost.com/somepath', body=self.empty_body.encode('ASCII'))
         with self.assertRaises(OfsMissingUrlError):
             get_url_from_req(http_req)
 

--- a/unittests.py
+++ b/unittests.py
@@ -1,0 +1,33 @@
+import json
+import unittest
+import azure.functions as func
+from IngestRawXmlHttpTrigger.utils import get_url_from_req, OfsMissingUrlError
+
+
+class TestGetUrlFromReq(unittest.TestCase):
+    def setUp(self):
+        self.test_url = 'http://somehost.com/somepath'
+        self.valid_data = {
+            'resource_url': self.test_url}
+        self.invalid_data = {
+            'invalid_name': self.test_url}
+
+    def test_with_valid_data(self):
+        """Test with valid body data"""
+        valid_body = json.dumps(self.valid_data)
+        http_req = func.HttpRequest(
+            method='post', url='http://somehost.com/somepath', body=valid_body.encode('ASCII'))
+        url = get_url_from_req(http_req)
+        self.assertEqual(url, self.test_url)
+
+    def test_with_invalid_data(self):
+        """Test with invalid POST body data"""
+        invalid_body = json.dumps(self.invalid_data)
+        http_req = func.HttpRequest(
+            method='post', url='http://somehost.com/somepath', body=invalid_body.encode('ASCII'))
+        with self.assertRaises(OfsMissingUrlError):
+            get_url_from_req(http_req)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### What

Added code to check a POST request and extract the resource_url

### How to review

Unittests:
    * Run the unit tests - python unittests.py

Functional tests:
    * Uncomment the hesa_url = .... line in __init__.py 
    * fire a post request in using test-scripts/post-url.sh
    * Try it with both valid and invalid body content