### PR TITLE
Feature/replace builtin xml dependency

### DIFF
--- a/CreateInstBlobTrigger/tests/conftest.py
+++ b/CreateInstBlobTrigger/tests/conftest.py
@@ -3,9 +3,10 @@ import os
 import sys
 
 CURRENTDIR = os.path.dirname(
-    os.path.abspath(inspect.getfile(inspect.currentframe())))
+    os.path.abspath(inspect.getfile(inspect.currentframe()))
+)
 PARENTDIR = os.path.dirname(CURRENTDIR)
 GRANDPARENTDIR = os.path.dirname(PARENTDIR)
 sys.path.insert(0, PARENTDIR)
 sys.path.insert(0, GRANDPARENTDIR)
-sys.path.append(os.path.join(CURRENTDIR, 'test_helpers'))
+sys.path.append(os.path.join(CURRENTDIR, "test_helpers"))

--- a/CreateInstBlobTrigger/tests/test_get_student_union.py
+++ b/CreateInstBlobTrigger/tests/test_get_student_union.py
@@ -1,6 +1,6 @@
 import json
 import unittest
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 from inst_test_utils import get_string
 from CreateInstBlobTrigger.locations import Locations

--- a/CreateInstBlobTrigger/tests/test_get_student_unions.py
+++ b/CreateInstBlobTrigger/tests/test_get_student_unions.py
@@ -1,6 +1,6 @@
 import json
 import unittest
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 from inst_test_utils import get_first, get_string
 from CreateInstBlobTrigger.locations import Locations
@@ -37,7 +37,6 @@ class TestGetStudentUnions(unittest.TestCase):
         )
         self.assertEqual(expected_student_unions, student_unions)
 
-
     def test_get_student_unions_413_courses(self):
 
         # Build a locations lookup
@@ -57,7 +56,6 @@ class TestGetStudentUnions(unittest.TestCase):
             get_string("fixtures/one_inst_413_courses.json")
         )
         self.assertEqual(expected_student_unions, student_unions)
-
 
 
 # TODO Test more of the functionality - more lookups etc

--- a/CreateInstBlobTrigger/tests/test_institution_docs.py
+++ b/CreateInstBlobTrigger/tests/test_institution_docs.py
@@ -1,6 +1,6 @@
 import json
 import unittest
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 from unittest import mock
 

--- a/CreateInstBlobTrigger/tests/test_location.py
+++ b/CreateInstBlobTrigger/tests/test_location.py
@@ -1,5 +1,5 @@
 import unittest
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 from inst_test_utils import get_string
 from CreateInstBlobTrigger.locations import Locations

--- a/CreateUkrlpBlobTrigger/__init__.py
+++ b/CreateUkrlpBlobTrigger/__init__.py
@@ -13,6 +13,7 @@ from azure.storage.blob import BlockBlobService
 
 from .lookup_creator import LookupCreator
 
+
 def main(xmlblob: func.InputStream):
     """Creates the UKRLP lookup tables for later use
 
@@ -31,13 +32,19 @@ def main(xmlblob: func.InputStream):
     """
 
     try:
-        logging.info(f"CreateUkrlpBlobTrigger creating UKRLP lookups\n"
-                     f"Name: {xmlblob.name}\n"
-                     f"Blob Size: {xmlblob.length} bytes")
+        logging.info(
+            f"CreateUkrlpBlobTrigger creating UKRLP lookups\n"
+            f"Name: {xmlblob.name}\n"
+            f"Blob Size: {xmlblob.length} bytes"
+        )
 
-        create_ukrlp_start_datetime = datetime.today().strftime('%Y%m%d %H%M%S')
+        create_ukrlp_start_datetime = datetime.today().strftime(
+            "%Y%m%d %H%M%S"
+        )
 
-        logging.info(f'CreateUkrlp function started on {create_ukrlp_start_datetime}')
+        logging.info(
+            f"CreateUkrlp function started on {create_ukrlp_start_datetime}"
+        )
 
         # Read the compressed Blob into a BytesIO object
         compressed_file = io.BytesIO(xmlblob.read())
@@ -49,47 +56,55 @@ def main(xmlblob: func.InputStream):
         decompressed_file = compressed_gzip.read()
 
         # Decode the bytes into a string
-        xml_string = decompressed_file.decode('utf-8')
+        xml_string = decompressed_file.decode("utf-8")
 
         # Parse the xml and create the lookups
         lookup_creator = LookupCreator(xml_string)
         lookup_creator.create_ukrlp_lookups()
 
-
         #
         # Copy the compressed HESA XML to the Blob storage monitored by Etl pipeline
         #
-        storage_account_name = os.environ['AzureStorageAccountName']
-        storage_account_key = os.environ['AzureStorageAccountKey']
+        storage_account_name = os.environ["AzureStorageAccountName"]
+        storage_account_key = os.environ["AzureStorageAccountKey"]
 
         # Instantiate the Block Blob Service
         blob_service = BlockBlobService(
-            account_name = storage_account_name,
-            account_key = storage_account_key)
+            account_name=storage_account_name, account_key=storage_account_key
+        )
 
-        logging.info('Created Block Blob Service to Azure Storage Account {storage_account_name}')
+        logging.info(
+            "Created Block Blob Service to Azure Storage Account {storage_account_name}"
+        )
 
         # Copy the dummy HESA XML we've just processed to the ETL input BLOB container
-        output_container_name = os.environ['EtlInputContainerName']
-        dummy_etl_blob_name = os.environ['DummyEtlBlobName']
-        source_url = os.environ['CreateUkrlpSourceUrl']
+        output_container_name = os.environ["EtlInputContainerName"]
+        dummy_etl_blob_name = os.environ["DummyEtlBlobName"]
+        source_url = os.environ["CreateUkrlpSourceUrl"]
 
         source_url += xmlblob.name
-        blob_filename = xmlblob.name.split('/')[1]
-        destination_blob_name = f'{create_ukrlp_start_datetime}-{blob_filename}'
-        logging.info(f'Copy the XML we have processed to {destination_blob_name}')
+        blob_filename = xmlblob.name.split("/")[1]
+        destination_blob_name = (
+            f"{create_ukrlp_start_datetime}-{blob_filename}"
+        )
+        logging.info(
+            f"Copy the XML we have processed to {destination_blob_name}"
+        )
 
         blob_service.copy_blob(
-            container_name = output_container_name,
-            blob_name = destination_blob_name,
-            copy_source = source_url)
+            container_name=output_container_name,
+            blob_name=destination_blob_name,
+            copy_source=source_url,
+        )
 
-        create_ukrlp_end_datetime = datetime.today().strftime('%Y%m%d %H%M%S')
-        logging.info(f'CreateUkrlp successfully finished on {create_ukrlp_end_datetime}')
+        create_ukrlp_end_datetime = datetime.today().strftime("%Y%m%d %H%M%S")
+        logging.info(
+            f"CreateUkrlp successfully finished on {create_ukrlp_end_datetime}"
+        )
 
     except Exception as e:
         # Unexpected exception
-        logging.error('Unexpected exception')
+        logging.error("Unexpected exception")
         logging.error(traceback.format_exc())
 
         # Raise to Azure

--- a/CreateUkrlpBlobTrigger/helper.py
+++ b/CreateUkrlpBlobTrigger/helper.py
@@ -7,7 +7,7 @@ class Helper:
 
         if isinstance(term, dict):
             return [term]
-        
+
         return term
 
     @staticmethod
@@ -15,8 +15,13 @@ class Helper:
         """Returns a single name for the provider"""
 
         # Get provider name if alias does not exist in ukrlp response body
-        if 'ProviderAliases' in matching_provider_records and matching_provider_records['ProviderAliases'] is not None:
-            aliases = Helper.get_list(matching_provider_records['ProviderAliases'])
-            return aliases[0]['ProviderAlias']
-        
-        return matching_provider_records['ProviderName']
+        if (
+            "ProviderAliases" in matching_provider_records
+            and matching_provider_records["ProviderAliases"] is not None
+        ):
+            aliases = Helper.get_list(
+                matching_provider_records["ProviderAliases"]
+            )
+            return aliases[0]["ProviderAlias"]
+
+        return matching_provider_records["ProviderName"]

--- a/CreateUkrlpBlobTrigger/lookup_creator.py
+++ b/CreateUkrlpBlobTrigger/lookup_creator.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 import os
 import sys
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 import xmltodict
 

--- a/CreateUkrlpBlobTrigger/ukrlp_client.py
+++ b/CreateUkrlpBlobTrigger/ukrlp_client.py
@@ -39,23 +39,23 @@ class UkrlpClient:
     def get_matching_provider_records(ukprn):
         """Calls the UKRLP API to get records for the ukprn passed in"""
 
-        url = os.environ['UkRlpUrl']
-        ofs_id = os.environ['UkRlpOfsId']
+        url = os.environ["UkRlpUrl"]
+        ofs_id = os.environ["UkRlpOfsId"]
 
-
-        headers = {'Content-Type': 'text/xml'}
+        headers = {"Content-Type": "text/xml"}
 
         soap_req = UkrlpClient.get_soap_req(ukprn, ofs_id)
         response = requests.post(url, data=soap_req, headers=headers)
         if response.status_code != 200:
             return None
 
-        decoded_content = response.content.decode('utf-8')
+        decoded_content = response.content.decode("utf-8")
         enrichment_data_dict = xmltodict.parse(decoded_content)
 
         try:
-            provider_records = enrichment_data_dict['S:Envelope']['S:Body'][
-                'ns4:ProviderQueryResponse']['MatchingProviderRecords']
+            provider_records = enrichment_data_dict["S:Envelope"]["S:Body"][
+                "ns4:ProviderQueryResponse"
+            ]["MatchingProviderRecords"]
         except KeyError:
             return None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 azure-cosmos==3.1.0
-azure-functions==1.0.0b5
-azure-functions-worker==1.0.0b6
+azure-functions==1.0.3
+azure-functions-worker==1.0.0
 azure-storage-blob==2.0.1
 defusedxml==0.6.0
 xmljson==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ azure-cosmos==3.1.0
 azure-functions==1.0.0b5
 azure-functions-worker==1.0.0b6
 azure-storage-blob==2.0.1
-defusedxml
+defusedxml==0.6.0
 xmljson==0.2.0
 xmlschema==1.0.11
 xmltodict==0.12.0


### PR DESCRIPTION
### What

Replace the xml parser that is part of the stdlib with defusedxml as it mitigates against known attacks. 

### How to review

Review the code

Use your favourite text searching tool to check the codebase and make sure our code is no longer using the stdlib xml.etree.ElementTree parser.